### PR TITLE
Fixed the missing marker in app binary for API_LEVEL > 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ DEFINES += HAVE_BOLOS_APP_STACK_CANARY
 # the apdu should not contain a crc.
 DEFINES += HAVE_COUNTER_MARKER
 ENABLE_NOCRC_APP_LOAD_PARAMS = 1
+# required for the marker to be found in the app binary
+CFLAGS += -mno-movt
 
 # Disable resetGeneration increment during ctap2 reset
 # This means credentials that are not discoverable won't be properly


### PR DESCRIPTION
Following this SDK change https://github.com/LedgerHQ/ledger-secure-sdk/commit/fe83e728412cdc0baf25da22d3f630c7d4df568f