### PR TITLE
fix: Sensitive key material not zeroed on stack in derive_and_store_keys

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -29,6 +29,7 @@ config_t const N_u2f_real;
 
 static int derive_and_store_keys(uint32_t resetGeneration) {
     cx_err_t error;
+    int status = -1;
     uint8_t key[64];
     uint8_t derivateKey[CX_SHA256_SIZE];
     uint32_t keyPath[3];
@@ -41,11 +42,12 @@ static int derive_and_store_keys(uint32_t resetGeneration) {
     keyPath[0] = PRIVATE_KEY_SEED_PATH;
     error = os_derive_bip32_no_throw(CX_CURVE_SECP256R1, keyPath, 3, key, key + 32);
     if (error != CX_OK) {
-        return -1;
+        goto exit;
     }
     if (memcmp(key, (uint8_t *) N_u2f.privateKeySeed, sizeof(N_u2f.privateKeySeed)) == 0) {
         // Keys are already initialized with the proper seed and resetGeneration
-        return 0;
+        status = 0;
+        goto exit;
     }
     nvm_write((void *) N_u2f.privateKeySeed, (void *) key, sizeof(N_u2f.privateKeySeed));
 
@@ -53,7 +55,7 @@ static int derive_and_store_keys(uint32_t resetGeneration) {
     keyPath[0] = WRAPPING_KEY_PATH;
     error = os_derive_bip32_no_throw(CX_CURVE_SECP256R1, keyPath, 3, key, key + 32);
     if (error != CX_OK) {
-        return -1;
+        goto exit;
     }
 
     // wrappingKeyU2F: aes_key = SHA256(VERSION || wrappingKeys)
@@ -68,7 +70,11 @@ static int derive_and_store_keys(uint32_t resetGeneration) {
               (void *) derivateKey,
               sizeof(N_u2f.wrappingKeyCTAP2));
 
-    return 0;
+    status = 0;
+exit:
+    explicit_bzero(key, sizeof(key));
+    explicit_bzero(derivateKey, sizeof(derivateKey));
+    return status;
 }
 
 int config_init(void) {


### PR DESCRIPTION
Closes #114

## Summary

Automated security fix for **Sensitive key material not zeroed on stack in derive_and_store_keys** (High).

**CWE**: CWE-CWE-316
**OWASP**: A02:2021-Cryptographic Failures
**Fix Confidence**: high

## What Changed
Added explicit_bzero() calls to clear the sensitive `key` and `derivateKey` stack buffers before returning from `derive_and_store_keys`. Converted the multiple return paths into a single `goto exit` pattern that zeroes both buffers, ensuring all paths (error returns at lines 46/57, early return at line 49, and normal return at line 71) properly clean up sensitive key material. This matches the existing pattern used throughout the codebase (e.g., crypto.c:102).

## Caveats
- The keyPath array is not zeroed as it contains only derivation path indices (not secret material). The suggested fix mentioned zeroing it but it's not necessary for security.
- derivateKey may be uninitialized on early exit paths, but explicit_bzero on uninitialized stack memory is safe and ensures no residual data remains.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
