### PR TITLE
fix: Missing return after NFC error in ctap2_reset_handle allows reset UX to proceed

### DIFF
--- a/src/ctap2/reset/reset.c
+++ b/src/ctap2/reset/reset.c
@@ -34,6 +34,7 @@ void ctap2_reset_handle(u2f_service_t *service, uint8_t *buffer, uint16_t length
         // Denied authenticatorReset over NFC as it can't be approved by the user.
         // Note, this is a behavior allowed by the FIDO spec.
         send_cbor_error(&G_io_u2f, ERROR_OPERATION_DENIED);
+        return;
     }
 
     PRINTF("ctap2_reset_handle\n");


### PR DESCRIPTION
Closes #115

## Summary

Automated security fix for **Missing return after NFC error in ctap2_reset_handle allows reset UX to proceed** (High).

**CWE**: CWE-CWE-670
**OWASP**: A01:2021-Broken Access Control
**Fix Confidence**: high

## What Changed
Added `return;` after `send_cbor_error()` in the NFC branch to prevent fall-through to `ctap2_reset_ux()`. Without this, an NFC reset request would send the error response but then also proceed to show the reset UX, potentially allowing a full authenticator reset over NFC.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
