### PR TITLE
FIX : two-screens/beeps on get_assertion - the assertion with up=0 is non-interactive

### DIFF
--- a/src/ctap2/get_assertion/get_assertion_utils.c
+++ b/src/ctap2/get_assertion/get_assertion_utils.c
@@ -646,8 +646,12 @@ void get_assertion_send(void) {
 
 exit:
     if (status == 0) {
+        // A silent assertion (up=0) is a non-interactive pre-flight probe that is fired
+        // just before the real (up=1) getAssertion. Therefore, we must not arm the NBGL
+        // status screen for it; we only need to show it for the user-present assertion.
+        const char *status_str = ctap2AssertData->userPresenceRequired ? CTAP2_LOGIN : NULL;
         // 1 + dataLen: 210
-        send_cbor_response(&G_io_u2f, 1 + dataLen, CTAP2_LOGIN);
+        send_cbor_response(&G_io_u2f, 1 + dataLen, status_str);
     } else {
         PRINTF("GET_ASSERTION build / encoding failed '%d'\n", status);
         send_cbor_error(&G_io_u2f, status);


### PR DESCRIPTION
# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [x] App update process has been followed <!-- See comment below -->
- [x] Target branch is `develop` <!-- unless you have a very good reason -->
- [x] Application version has been bumped - not needed <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/device-app/deliver/maintenance before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->
